### PR TITLE
Update to support newer Hapi.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 8
+  - 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 8
+  - 12.12.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 12
+  - 8

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,11 +8,11 @@ exports.plugin = {
 
                 if (request.headers['x-forwarded-for']) {
 
-                    request.info.remoteAddress = request.headers['x-forwarded-for'].split(',')[0].trim();
+                    request.info._remoteAddress = request.headers['x-forwarded-for'].split(',')[0].trim();
                 }
 
                 if (request.headers['x-forwarded-port']) {
-                    request.info.remotePort = request.headers['x-forwarded-port'];
+                    request.info._remotePort = request.headers['x-forwarded-port'];
                 }
 
                 return h.continue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "therealyou",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "hapi.js plugin for setting the remoteAddress and remotePort based on the X-Forwarded-For and X-Forwarded-Port headers",
   "main": "lib/index.js",
   "author": "Brian Delahunty <brian@briandela.com>",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "code": "5.1.2",
     "coveralls": "^3.0.0",
-    "hapi": "^17",
+    "hapi": "^19",
     "lab": "15",
     "pre-commit": "^1.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
   ],
   "homepage": "https://github.com/briandela/therealyou",
   "devDependencies": {
-    "code": "5.1.2",
-    "coveralls": "^3.0.0",
+    "@hapi/code": "^8.0.1",
     "@hapi/hapi": "^19.0.5",
-    "lab": "15",
-    "pre-commit": "^1.1.3"
+    "@hapi/lab": "^22.0.3",
+    "coveralls": "^3.0.9",
+    "pre-commit": "^1.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "code": "5.1.2",
     "coveralls": "^3.0.0",
-    "hapi": "^19",
+    "hapi": "^19.0.5",
     "lab": "15",
     "pre-commit": "^1.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "code": "5.1.2",
     "coveralls": "^3.0.0",
-    "hapi": "^19.0.5",
+    "@hapi/hapi": "^19.0.5",
     "lab": "15",
     "pre-commit": "^1.1.3"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,6 @@
-'use strict';
-
-const Lab = require('lab');
+const Lab = require('@hapi/lab');
 const Hapi = require('@hapi/hapi');
-const Code = require('code');
+const Code = require('@hapi/code');
 
 const lab = (exports.lab = Lab.script());
 const expect = Code.expect;
@@ -114,7 +112,7 @@ describe('x-forwarded-port', () => {
         };
 
         const res = await server.inject(requestOptions);
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.be.equal('');
+        expect(res.statusCode).to.equal(204);
+        expect(res.result).to.be.equal(null);
     });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Lab = require('lab');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Code = require('code');
 
 const lab = (exports.lab = Lab.script());


### PR DESCRIPTION
Hapi newer versions don't support this and it needs to be `info._remoteAddress` etc.

remoteAddress is just a getter function and in order to change the value you must change the property directly using `_remoteAddress`.

Just note that `request.info`  is a read-only property so maybe they don't want it to be different than what they have.

https://hapi.dev/api/?v=19.1.0#-requestinfo